### PR TITLE
set zindex to -999 if tip is not visible

### DIFF
--- a/lib/ActionTip.js
+++ b/lib/ActionTip.js
@@ -52,7 +52,7 @@ const ActionTip = React.forwardRef((props, ref) => {
     return (React.createElement(TouchableWithoutFeedback, { onPress: hide },
         React.createElement(Animated.View, { style: [
                 styles.defaultActionTipStyle,
-                containerStyle,
+                [containerStyle, {zIndex: isVisible ? 999 : -999}],
                 {
                     top,
                     bottom,


### PR DESCRIPTION
This implementation add zIndex: -999 to avoid the action tip being displayed on screen even if is not visible